### PR TITLE
Set up and use a config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.4 (development)
+ * Open file dialog for selecting videos in the same location as the last run,
+    rather than in the present working directory. For the first run, the
+    behavior is unchanged.
+
 ## 0.0.3 (05.25.2017)
  * Don't restart video when current frame is also the last (useable) frame.
  * Overwrite existing graph(s) instead of appending - prevents formatting errors


### PR DESCRIPTION
RespiRate now saves the last working directory (the location of the last
video that was loaded) in ~/.RespiRate/RRconf.txt. This allows RespiRate
to remember the last working directory between runs and automatically
open the file dialog for selecting videos in that directory, rather than
the user having to navigate to it each time RespiRate is started.
BEFORE:
Start RespiRate, select "Open Video", navigate to the video directory
each time (though not **during** a session, only on new sessions).
AFTER:
Start RespiRate, select "Open Video", and file manager is opened in the
same location as the last used video. For the first run, RespiRate will
open in the present working directory, just like before.

If we add the ability for the user to select the destination of the
spreadsheet, we'll need to save the destination in the config file
as well.